### PR TITLE
allow to create groups without permissions and bugfix

### DIFF
--- a/aem_group.py
+++ b/aem_group.py
@@ -261,10 +261,7 @@ class AEMGroup(object):
         if not self.module.check_mode and self.groups:
             for group in self.groups:
                 fields['memberEntry'] = group
-                r = requests.post(self.url + '%s' % self.path, auth=self.auth,
-                                  files={
-                                      "memberAction": "addMembers",
-                                      "memberEntry": "administrators"})
+                r = requests.post(self.url + '%s' % self.path, auth=self.auth, data=fields)
             if r.status_code != 200:
                 self.module.fail_json(msg='failed to update groups: %s - %s' % (r.status_code, r.text))
         self.changed = True

--- a/aem_group.py
+++ b/aem_group.py
@@ -201,7 +201,8 @@ class AEMGroup(object):
                 groups = ','.join(self.groups).lower()
                 if curr_groups != groups:
                     self.update_groups()
-            self.add_permissions()
+            if self.permissions:
+                self.add_permissions()
             if self.root_groups:
                 self.get_root_groups_path()
                 self.add_to_root_groups()
@@ -210,7 +211,8 @@ class AEMGroup(object):
             if not self.name:
                 self.module.fail_json(msg='Missing required argument: name')
             self.create_group()
-            self.add_permissions()
+            if self.permissions:
+                self.add_permissions()
             if self.root_groups:
                 self.get_root_groups_path()
                 self.add_to_root_groups()


### PR DESCRIPTION
This allows to create groups without assigning them permissions, which can be usefull if you want to use nested groups.

The second commit will fix the update group for adding new group members. It was hardcoded to the administrators group,