### PR TITLE
Update aem_agent.py

### DIFF
--- a/aem_agent.py
+++ b/aem_agent.py
@@ -536,7 +536,8 @@ class AEMAgent(object):
     # --------------------------------------------------------------------------------
     def delete_agent(self):
         if not self.module.check_mode:
-            r = requests.delete(self.url + '/etc/replication/%s/%s' % (self.folder, self.name), auth=self.auth)
+            r_data= {':operation': 'delete'}
+            r = requests.post(self.url + '/etc/replication/%s/%s' % (self.folder, self.name), auth=self.auth, data = r_data)
             if r.status_code != 204:
                 self.module.fail_json(msg='failed to delete agent: %s - %s' % (r.status_code, r.text))
         self.changed = True


### PR DESCRIPTION
I propose this changes as part of fixing the issue whith deleting replication agent (methot DELETE isn't supported).
More details can be found here:
https://stackoverflow.com/questions/66422490/error-deleting-obsolete-flush-agents-using-ansible-aem-agent-module/66437842#66437842
and here:
https://sling.apache.org/documentation/bundles/manipulating-content-the-slingpostservlet-servlets-post.html#content-removal